### PR TITLE
Ginger Payments API check for null values in JSON

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -393,7 +393,7 @@ final class Client
                     "orders/".$order->id()."/",
                     [
                         "timeout" => 3,
-                        "json" => $order->toArray()
+                        "json" => ArrayFunctions::withoutNullValues($order->toArray())
                     ]
                 )->json()
             );

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -369,7 +369,7 @@ final class ClientTest extends \PHPUnit_Framework_TestCase
                 m::on(
                     function (array $options) use ($order) {
                         $this->assertEquals(
-                            $order->toArray(),
+                            ArrayFunctions::withoutNullValues($order->toArray()),
                             $options['json']
                         );
                         return true;


### PR DESCRIPTION
So null values should be stripped out from the request body.